### PR TITLE
Fix bosh CPI to use https based communication instead of http

### DIFF
--- a/src/bosh-alicloud-cpi/alicloud/common.go
+++ b/src/bosh-alicloud-cpi/alicloud/common.go
@@ -88,7 +88,7 @@ func getSdkConfig() *sdk.Config {
 		WithGoRoutinePoolSize(10).
 		WithDebug(false).
 		WithHttpTransport(getTransport()).
-		WithScheme("https")
+		WithScheme("HTTPS")
 }
 
 func getTransport() *http.Transport {

--- a/src/bosh-alicloud-cpi/alicloud/common.go
+++ b/src/bosh-alicloud-cpi/alicloud/common.go
@@ -87,7 +87,8 @@ func getSdkConfig() *sdk.Config {
 		WithUserAgent(getUserAgent()).
 		WithGoRoutinePoolSize(10).
 		WithDebug(false).
-		WithHttpTransport(getTransport())
+		WithHttpTransport(getTransport()).
+		WithScheme("https")
 }
 
 func getTransport() *http.Transport {


### PR DESCRIPTION
Bosh CPI communicate with the IaaS APIs should be over https