### PR TITLE
Fix full stemcell create flow

### DIFF
--- a/src/bosh-alicloud-cpi/action/create_stemcell.go
+++ b/src/bosh-alicloud-cpi/action/create_stemcell.go
@@ -15,6 +15,11 @@ import (
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	"github.com/cppforlife/bosh-cpi-go/apiv1"
 	"github.com/google/uuid"
+	"os"
+	"io"
+	"os/exec"
+	"bytes"
+	"path"
 )
 
 const (

--- a/src/bosh-alicloud-cpi/action/create_stemcell.go
+++ b/src/bosh-alicloud-cpi/action/create_stemcell.go
@@ -21,6 +21,7 @@ const (
 	AlicloudImageNamePrefix    = "stemcell"
 	MinImageDiskSize           = 5 //in GB
 	OSS_BUCKET_NAME_MAX_LENGTH = 64
+	PART_SIZE = 5*1024*1024
 )
 
 type StemcellProps struct {

--- a/src/bosh-alicloud-cpi/action/create_stemcell.go
+++ b/src/bosh-alicloud-cpi/action/create_stemcell.go
@@ -10,13 +10,13 @@ import (
 	"strconv"
 	"strings"
 
+	"bytes"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	"github.com/cppforlife/bosh-cpi-go/apiv1"
 	"github.com/google/uuid"
 	"os/exec"
-	"bytes"
 	"path"
 )
 
@@ -24,7 +24,7 @@ const (
 	AlicloudImageNamePrefix    = "stemcell"
 	MinImageDiskSize           = 5 //in GB
 	OSS_BUCKET_NAME_MAX_LENGTH = 64
-	PART_SIZE = 5*1024*1024
+	PART_SIZE                  = 5 * 1024 * 1024
 )
 
 type StemcellProps struct {
@@ -33,10 +33,10 @@ type StemcellProps struct {
 	Disk            interface{} `json:"disk"`
 	DiskFormat      string      `json:"disk_format"`
 	diskGB          int
-	Hypervisor      string `json:"hypervisor"`
-	Name            string `json:"name"`
-	OsDistro        string `json:"os_distro"`
-	OsType          string `json:"os_type"`
+	Hypervisor      string      `json:"hypervisor"`
+	Name            string      `json:"name"`
+	OsDistro        string      `json:"os_distro"`
+	OsType          string      `json:"os_type"`
 	//RootDeviceName string 	`json:"root_device_name"`
 	SourceUrl string `json:"source_url"`
 	//SourceSha1    string `json:"raw_disk_sha1,omitempty"`
@@ -217,7 +217,7 @@ func (a CreateStemcellMethod) CreateFromTarball(imagePath string, props Stemcell
 	err = cmd.Run()
 
 	if err != nil {
-		return "", bosherr.WrapErrorf(err, fmt.Sprintf("%s-(%s)-(%s)", "Unable to extract image", out.String(),stderr.String()))
+		return "", bosherr.WrapErrorf(err, fmt.Sprintf("%s-(%s)-(%s)", "Unable to extract image", out.String(), stderr.String()))
 	}
 
 	err = a.osses.UploadFile(*bucket, imageName, fmt.Sprintf("%s/%s", path.Dir(imagePath), "root.img"), PART_SIZE, oss.Routines(5))

--- a/src/bosh-alicloud-cpi/action/create_stemcell.go
+++ b/src/bosh-alicloud-cpi/action/create_stemcell.go
@@ -15,8 +15,6 @@ import (
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	"github.com/cppforlife/bosh-cpi-go/apiv1"
 	"github.com/google/uuid"
-	"os"
-	"io"
 	"os/exec"
 	"bytes"
 	"path"


### PR DESCRIPTION
This fix solves the vm unbootable error that happen when you try to upload a full stemcell version from bosh.io

- Fixed part size too small issue when uploading a 3.5GB image
- Fixed - Extract stemcell image to get raw image