### PR TITLE
fix device name (xvdc -> vdc) for disk category cloud_ssd

### DIFF
--- a/src/bosh-alicloud-cpi/alicloud/disk_manager.go
+++ b/src/bosh-alicloud-cpi/alicloud/disk_manager.go
@@ -370,7 +370,7 @@ func AmendDiskPath(path string, category DiskCategory) string {
 	// cloud_efficiency:
 	// cloud_ssd:
 	// ephemeral_ssd:
-	if category == DiskCategoryCloudEfficiency {
+	if category == DiskCategoryCloudEfficiency || category == DiskCategoryCloudSSD{
 		if path[5] == 'x' {
 			path = "/dev/" + string(path[6:])
 		}

--- a/src/bosh-alicloud-cpi/alicloud/disk_manager_test.go
+++ b/src/bosh-alicloud-cpi/alicloud/disk_manager_test.go
@@ -17,7 +17,7 @@ var _ = Describe("DiskManager", func() {
 		By("cloud_efficiency /dev/vdc -> /dev/vdc")
 		Expect(AmendDiskPath("/dev/vdc", alicloud.DiskCategoryCloudEfficiency)).To(Equal("/dev/vdc"))
 		By("ssd /dev/xvdc -> /dev/xvdc")
-		Expect(AmendDiskPath("/dev/xvdc", alicloud.DiskCategoryCloudSSD)).To(Equal("/dev/xvdc"))
+		Expect(AmendDiskPath("/dev/xvdc", alicloud.DiskCategoryCloudSSD)).To(Equal("/dev/vdc"))
 		By("ssd /dev/vdc -> /dev/vdc")
 		Expect(AmendDiskPath("/dev/vdc", alicloud.DiskCategoryCloudEfficiency)).To(Equal("/dev/vdc"))
 	})


### PR DESCRIPTION
Hi,

This is a fix for issue: bosh CPI error when using disk category 'cloud_ssd'
https://github.com/cloudfoundry-incubator/bosh-alicloud-cpi-release/issues/57
