### PR TITLE
Use internal OSS endpoint by default

### DIFF
--- a/src/bosh-alicloud-cpi/alicloud/config.go
+++ b/src/bosh-alicloud-cpi/alicloud/config.go
@@ -245,7 +245,7 @@ func (c Config) NewOssClient(region string) (*oss.Client, error) {
 			}
 			endpoint = endpointItem.Endpoint
 		} else {
-			endpoint = fmt.Sprintf("oss-%s.aliyuncs.com", c.OpenApi.Region)
+			endpoint = fmt.Sprintf("oss-%s-internal.aliyuncs.com", c.OpenApi.Region)
 		}
 	}
 	if !strings.HasPrefix(endpoint, "http") {


### PR DESCRIPTION
Hi,

It makes sense to use internal bucket endpoint by default, due to several reasons:
1) It faster and more secure (no outgoing internet traffic) and work even in VPC without NAT gateway
2) Internal endpoints for OSS service is always available and doesn't require any activation (like private endpoint feature)

Thanks