### PR TITLE
support darwin golang; allow any golang version [fixes #80, fixes #36]

### DIFF
--- a/packages/bosh-alicloud-cpi/packaging
+++ b/packages/bosh-alicloud-cpi/packaging
@@ -1,39 +1,25 @@
+#!/bin/bash
+
 set -e # exit immediately if a simple command exits with a non-zero status
 set -u # report the usage of uninitialized variables
 
-# Set package dependencies directory
+# Available variables
+# $BOSH_COMPILE_TARGET - where this package & spec'd source files are available
+# $BOSH_INSTALL_TARGET - where you copy/install files to be included in package
+
+export HOME=${HOME:-/tmp/home}
 PACKAGES_DIR=${BOSH_PACKAGES_DIR:-/var/vcap/packages}
 
 # Set Golang dependency
-PLATFORM=`uname | tr '[:upper:]' '[:lower:]'`
+export GOROOT=$(cd "${PACKAGES_DIR}/golang" && pwd -P)
+ls -alR $GOROOT/bin
+export PATH=${GOROOT}/bin:${PATH}
 
-if [ $PLATFORM = "linux" ]; then
-    export GOROOT=$(cd "${PACKAGES_DIR}/golang" && pwd -P)
-    export PATH=${GOROOT}/bin:${PATH}
-fi
-
-# Build BOSH Alicloud CPI package
-echo " ========================================== "
-echo " Source Patch: " $BOSH_COMPILE_TARGET
-echo " Installed in: " $BOSH_INSTALL_TARGET
-echo " ========================================== "
-
-mkdir -p ${BOSH_COMPILE_TARGET}/go/src
-mv ${BOSH_COMPILE_TARGET}/Makefile ${BOSH_COMPILE_TARGET}/go/
-mv ${BOSH_COMPILE_TARGET}/bosh-alicloud-cpi ${BOSH_COMPILE_TARGET}/go/src/
-# mv ${BOSH_COMPILE_TARGET}/github.com ${BOSH_COMPILE_TARGET}/go/src/
-
-export GOPATH=${BOSH_COMPILE_TARGET}/go
-
-# Copy BOSH Alicloud CPI package
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
 
-cd ${BOSH_COMPILE_TARGET}/go
-make
-
-## TODO replace with a single command
-## EXECUTABLE=bin/alicloud_cpi
-## go build -v -a -o ${EXECUTABLE} $(MAINFILE)
-
-cp ${BOSH_COMPILE_TARGET}/go/bin/alicloud_cpi ${BOSH_INSTALL_TARGET}/bin/
-
+# Build BOSH alicloud CPI package
+mkdir -p ${BOSH_COMPILE_TARGET}/go/src
+mv ${BOSH_COMPILE_TARGET}/bosh-alicloud-cpi ${BOSH_COMPILE_TARGET}/go/src/
+cd ${BOSH_COMPILE_TARGET}/go/src/bosh-alicloud-cpi
+export GOPATH=${BOSH_COMPILE_TARGET}/go
+go build -o ${BOSH_INSTALL_TARGET}/bin/alicloud_cpi bosh-alicloud-cpi/main

--- a/packages/bosh-alicloud-cpi/spec
+++ b/packages/bosh-alicloud-cpi/spec
@@ -5,4 +5,3 @@ dependencies:
   - golang
 files:
   - bosh-alicloud-cpi/**/*
-  - Makefile

--- a/packages/golang/packaging
+++ b/packages/golang/packaging
@@ -1,17 +1,14 @@
+#!/bin/bash
+
 set -e # exit immediately if a simple command exits with a non-zero status
 set -u # report the usage of uninitialized variables
 
 # Grab the latest versions that are in the directory
 PLATFORM=`uname | tr '[:upper:]' '[:lower:]'`
 
-export GOLANG_VERSION=1.11.5
+# Extract Go Programming Language package
+tar xzvf ${BOSH_COMPILE_TARGET}/golang/go*.${PLATFORM}-amd64.tar.gz
 
-if [ $PLATFORM = "linux" ]; then
-    # Set package dependencies directory
-    export dir=`ls ${BOSH_COMPILE_TARGET}`
-    tar xzvf ${BOSH_COMPILE_TARGET}/go${GOLANG_VERSION}.linux-amd64.tar.gz
-
-    # Copy Go Programming Language package
-    mkdir -p ${BOSH_INSTALL_TARGET}/bin
-    cp -a ${BOSH_COMPILE_TARGET}/go/* ${BOSH_INSTALL_TARGET}
-fi
+# Copy Go Programming Language package
+mkdir -p ${BOSH_INSTALL_TARGET}/bin
+cp -R ${BOSH_COMPILE_TARGET}/go/* ${BOSH_INSTALL_TARGET}

--- a/packages/golang/spec
+++ b/packages/golang/spec
@@ -2,4 +2,5 @@
 name: golang
 
 files:
-  - go1.11.5.linux-amd64.tar.gz  # from https://storage.googleapis.com/golang/go1.11.5.linux-amd64.tar.gz
+- golang/go1.*.darwin-amd64.tar.gz  # from https://golang.org/dl/
+- golang/go1.*.linux-amd64.tar.gz  # from https://golang.org/dl/


### PR DESCRIPTION
This PR helpfully adds mac/darwin support to the CPI `bosh create-env` command. It also makes it very easy to upgrade to new golang versions in future by only replacing the blobs (no changes required to the `packages/golang/` files).

To test this PR:

First, add a darwin golang to blobs (and let's upgrade to 1.12.6 whilst we're at it; but please can we move to a public blobstore too? #77)

```
mkdir -p tmp
curl https://dl.google.com/go/go1.12.6.linux-amd64.tar.gz -o tmp/go1.12.6.linux-amd64.tar.gz
curl https://dl.google.com/go/go1.12.6.darwin-amd64.tar.gz -o tmp/go1.12.6.darwin-amd64.tar.gz
bosh add-blob tmp/go1.12.6.linux-amd64.tar.gz go1.12.6.linux-amd64.tar.gz
bosh add-blob tmp/go1.12.6.darwin-amd64.tar.gz go1.12.6.darwin-amd64.tar.gz
```

Next, create a dev release:

```
bosh create-release --version 22.0.$(date -u "+%Y%m%d%H%M%S") --tarball tmp/bosh-alicloud-cpi-release.tgz --force
```

An example operator file for a `bosh create-env` command is:

```
- type: replace
  path: /releases/-
  value:
    name: bosh-alicloud-cpi
    version: latest
    url: file:///path/to/bosh-alicloud-cpi-release/tmp/bosh-alicloud-cpi-release.tgz
```

Then apply the operator to your `bosh create-env` command.