### PR TITLE
Add blobstores field to BoshEnv struct

### DIFF
--- a/src/bosh-alicloud-cpi/registry/agent_settings.go
+++ b/src/bosh-alicloud-cpi/registry/agent_settings.go
@@ -82,14 +82,15 @@ type Env struct {
 }
 
 type BoshEnv struct {
-	Password              string   `json:"password"`
-	KeepRootPassword      bool     `json:"keep_root_password"`
-	RemoveDevTools        bool     `json:"remove_dev_tools"`
-	RemoveStaticLibraries bool     `json:"remove_static_libraries"`
-	AuthorizedKeys        []string `json:"authorized_keys"`
-	SwapSizeInMB          *uint64  `json:"swap_size"`
-	Mbus                  MBus     `json:"mbus"`
-	IPv6                  IPv6     `json:"ipv6"`
+	Password              string              `json:"password"`
+	KeepRootPassword      bool                `json:"keep_root_password"`
+	RemoveDevTools        bool                `json:"remove_dev_tools"`
+	RemoveStaticLibraries bool                `json:"remove_static_libraries"`
+	AuthorizedKeys        []string            `json:"authorized_keys"`
+	SwapSizeInMB          *uint64             `json:"swap_size"`
+	Mbus                  MBus                `json:"mbus"`
+	IPv6                  IPv6                `json:"ipv6"`
+	Blobstores            []BlobstoreSettings `json:"blobstores"`
 }
 
 type MBus struct {


### PR DESCRIPTION
Adds "Blobstores" field to BoshEnv struct. 
This should fix #132 

In general, agent_settings.go is out of sync with  the definition in bosh-agent project:
https://github.com/cloudfoundry/bosh-agent/blob/master/settings/settings.go#L276

Perhaps, to avoid further bugs, it is worth syncing more with the bosh-agent definition?