### PR TITLE
Add CR required bosh tag when create vm

### DIFF
--- a/src/bosh-alicloud-cpi/action/create_vm.go
+++ b/src/bosh-alicloud-cpi/action/create_vm.go
@@ -225,7 +225,7 @@ func (a CreateVMMethod) createVM(
 		})
 	}
 	// 为了支持CR，tag中添加创建时获取的director和deployment。 获取registryEnv.Bosh.Group , 格式：<director-name>-<deployment-name>-<job-name> 解析出 director-name 和 deployment-name
-	if registryEnv.Bosh.Group != nil && registryEnv.Bosh.Group != "" {
+	if registryEnv.Bosh.Group != "" {
 		groupItems := strings.Split(registryEnv.Bosh.Group, "-")
 		if len(groupItems) > 1 {
 			directorName := groupItems[0]

--- a/src/bosh-alicloud-cpi/action/create_vm.go
+++ b/src/bosh-alicloud-cpi/action/create_vm.go
@@ -224,17 +224,17 @@ func (a CreateVMMethod) createVM(
 			Value: fmt.Sprint(v),
 		})
 	}
-	// 为了支持CR，此处需要显示设置上系统Tag。 获取registryEnv.Bosh.Group , 格式：<director-name>-<deployment-name>-<job-name> 解析出 director-name 和 deployment-name
+	// 为了支持CR，tag中添加创建时获取的director和deployment。 获取registryEnv.Bosh.Group , 格式：<director-name>-<deployment-name>-<job-name> 解析出 director-name 和 deployment-name
 	group_items := strings.Split(registryEnv.Bosh.Group, "-")
 	if len(group_items) > 1 {
 		director_name := group_items[0]
 		deployment_name := group_items[1]
 		tags = append(tags, ecs.CreateInstanceTag{
-			Key: "director",
+			Key: "bootstrap-director",
 			Value: director_name,
 		})
 		tags = append(tags, ecs.CreateInstanceTag{
-			Key: "deployment",
+			Key: "bootstrap-deployment",
 			Value: deployment_name,
 		})
 	}

--- a/src/bosh-alicloud-cpi/action/create_vm.go
+++ b/src/bosh-alicloud-cpi/action/create_vm.go
@@ -224,6 +224,22 @@ func (a CreateVMMethod) createVM(
 			Value: fmt.Sprint(v),
 		})
 	}
+	// 为了支持CR，此处需要显示设置上系统Tag。 获取registryEnv.Bosh.Group , 格式：<director-name>-<deployment-name>-<job-name> 解析出 director-name 和 deployment-name
+	group_items := strings.Split(registryEnv.Bosh.Group, "-")
+	if len(group_items) > 1 {
+		director-name := group_items[0]
+		deployment-name := group_items[1]
+		preDefineTags := map[string]string{
+			"deployment": deployment-name,
+			"director":director-name,
+		}
+		for key, value := range preDefineTags {
+			tags = append(tags, ecs.CreateInstanceTag{
+				Key: key,
+				Value: value,
+			})
+		}
+	}
 	// 接下来获取manifest中的tag
 	for k, v := range instProps.Tags {
 		tags = append(tags, ecs.CreateInstanceTag{

--- a/src/bosh-alicloud-cpi/action/create_vm.go
+++ b/src/bosh-alicloud-cpi/action/create_vm.go
@@ -227,18 +227,16 @@ func (a CreateVMMethod) createVM(
 	// 为了支持CR，此处需要显示设置上系统Tag。 获取registryEnv.Bosh.Group , 格式：<director-name>-<deployment-name>-<job-name> 解析出 director-name 和 deployment-name
 	group_items := strings.Split(registryEnv.Bosh.Group, "-")
 	if len(group_items) > 1 {
-		director-name := group_items[0]
-		deployment-name := group_items[1]
-		preDefineTags := map[string]string{
-			"deployment": deployment-name,
-			"director":director-name,
-		}
-		for key, value := range preDefineTags {
-			tags = append(tags, ecs.CreateInstanceTag{
-				Key: key,
-				Value: value,
-			})
-		}
+		director_name := group_items[0]
+		deployment_name := group_items[1]
+		tags = append(tags, ecs.CreateInstanceTag{
+			Key: "director",
+			Value: director_name,
+		})
+		tags = append(tags, ecs.CreateInstanceTag{
+			Key: "deployment",
+			Value: deployment_name,
+		})
 	}
 	// 接下来获取manifest中的tag
 	for k, v := range instProps.Tags {

--- a/src/bosh-alicloud-cpi/action/create_vm.go
+++ b/src/bosh-alicloud-cpi/action/create_vm.go
@@ -225,18 +225,20 @@ func (a CreateVMMethod) createVM(
 		})
 	}
 	// 为了支持CR，tag中添加创建时获取的director和deployment。 获取registryEnv.Bosh.Group , 格式：<director-name>-<deployment-name>-<job-name> 解析出 director-name 和 deployment-name
-	group_items := strings.Split(registryEnv.Bosh.Group, "-")
-	if len(group_items) > 1 {
-		director_name := group_items[0]
-		deployment_name := group_items[1]
-		tags = append(tags, ecs.CreateInstanceTag{
-			Key: "bootstrap-director",
-			Value: director_name,
-		})
-		tags = append(tags, ecs.CreateInstanceTag{
-			Key: "bootstrap-deployment",
-			Value: deployment_name,
-		})
+	if registryEnv.Bosh.Group != nil && registryEnv.Bosh.Group != "" {
+		groupItems := strings.Split(registryEnv.Bosh.Group, "-")
+		if len(groupItems) > 1 {
+			directorName := groupItems[0]
+			deploymentName := groupItems[1]
+			tags = append(tags, ecs.CreateInstanceTag{
+				Key: "director",
+				Value: directorName,
+			})
+			tags = append(tags, ecs.CreateInstanceTag{
+				Key: "deployment",
+				Value: deploymentName,
+			})
+		}
 	}
 	// 接下来获取manifest中的tag
 	for k, v := range instProps.Tags {

--- a/src/bosh-alicloud-cpi/registry/agent_settings.go
+++ b/src/bosh-alicloud-cpi/registry/agent_settings.go
@@ -92,6 +92,7 @@ type BoshEnv struct {
 	IPv6                  IPv6                   `json:"ipv6"`
 	Blobstores            []BlobstoreSettings    `json:"blobstores"`
 	Tags                  map[string]interface{} `json:"tags"`
+	Group                 string                 `json:"group"`
 }
 
 type MBus struct {


### PR DESCRIPTION
Add two tags needed by CR: 'bootstrap-director' and 'bootstrap-deployment'. We can calculate director name and deployment name by using 'environment' argument 'group' element. See https://bosh.io/docs/cpi-api-v2-method/create-vm/