### PR TITLE
Add NTP field to BoshEnv struct

### DIFF
--- a/src/bosh-alicloud-cpi/registry/agent_settings.go
+++ b/src/bosh-alicloud-cpi/registry/agent_settings.go
@@ -91,6 +91,7 @@ type BoshEnv struct {
 	Mbus                  MBus                   `json:"mbus"`
 	IPv6                  IPv6                   `json:"ipv6"`
 	Blobstores            []BlobstoreSettings    `json:"blobstores"`
+	NTP                   []string               `json:"ntp"`
 	Tags                  map[string]interface{} `json:"tags"`
 	Group                 string                 `json:"group"`
 }


### PR DESCRIPTION
Similar to #133, the NTP field is missing. The missing field causes the recommended way to configure NTP as described in https://bosh.io/docs/ntp-config/#configuring-ntp-servers-in-the-director-itself to fail.

Btw the Google CPI seems to handle this generically: https://github.com/cloudfoundry/bosh-google-cpi-release/blob/f31024b544458c9032162834d91801b2eb3da1a6/src/bosh-google-cpi/registry/agent_settings.go#L71