### PR TITLE
go: download go1.24 for linux/amd64: toolchain not available

### DIFF
--- a/src/bosh-alicloud-cpi/go.mod
+++ b/src/bosh-alicloud-cpi/go.mod
@@ -1,6 +1,6 @@
 module bosh-alicloud-cpi
 
-go 1.24
+go 1.24.0
 
 require (
 	github.com/alibabacloud-go/darabonba-openapi/v2 v2.0.8


### PR DESCRIPTION
A known issue when specifying the go version in the mod file causes our blackduck scans to fail with error:

`go: download go1.24 for linux/amd64: toolchain not available
`
Adding a .0 solves the issue