### PR TITLE
Bump Go version to 1.26.1

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,3 @@
-go1.24.2.linux-amd64.tar.gz:
-  size: 78516109
-  sha: sha256:68097bd680839cbc9d464a0edce4f7c333975e27a90246890e9f1078c7e702ad
+go1.26.1.linux-amd64.tar.gz:
+  size: 66791587
+  sha: sha256:031f088e5d955bab8657ede27ad4e3bc5b7c1ba281f05f245bcc304f327c987a

--- a/src/bosh-alicloud-cpi/go.mod
+++ b/src/bosh-alicloud-cpi/go.mod
@@ -1,6 +1,6 @@
 module bosh-alicloud-cpi
 
-go 1.24.2
+go 1.26.1
 
 require (
 	github.com/alibabacloud-go/darabonba-openapi/v2 v2.0.8


### PR DESCRIPTION
## Summary
Bump Go version from 1.24.2 to 1.26.1 to address security vulnerabilities.

## Security Fixes
- CVE-2024-45337 (crypto/x509)
- CVE-2023-45288 (x/net)

## Changes
- config/blobs.yml: Update Go blob to 1.26.1
- src/bosh-alicloud-cpi/go.mod: Update Go toolchain version