### PR TITLE
Enable NVME support on imageCopy

### DIFF
--- a/src/bosh-alicloud-cpi/action/create_stemcell.go
+++ b/src/bosh-alicloud-cpi/action/create_stemcell.go
@@ -231,6 +231,15 @@ func (a CreateStemcellMethod) copyImage(stemcellId string, props StemcellProps) 
 		a.cleanUp(imageId)
 		return "", bosherr.WrapError(err, "Failed to copy Alicloud Image")
 	}
+
+	// CopyImage does not propagate Features.NvmeSupport from the source image.
+	// Apply ModifyImageAttribute on the copy so c9i/g9i/r9i can boot from the
+	// encrypted copy (this is the image actually used to launch VMs).
+	if err = a.stemcells.EnableNvmeSupport(imageId); err != nil {
+		a.cleanUp(imageId)
+		return "", bosherr.WrapError(err, "Failed to enable NvmeSupport on copied Alicloud Image")
+	}
+
 	a.Logger.Debug(alicloud.AlicloudImageServiceTag, "Copy Alicloud Image %s success", imageId)
 
 	// If the full stemcell, the raw image should be deleted after copied

--- a/src/bosh-alicloud-cpi/action/create_stemcell.go
+++ b/src/bosh-alicloud-cpi/action/create_stemcell.go
@@ -233,8 +233,6 @@ func (a CreateStemcellMethod) copyImage(stemcellId string, props StemcellProps) 
 	}
 
 	// CopyImage does not propagate Features.NvmeSupport from the source image.
-	// Apply ModifyImageAttribute on the copy so c9i/g9i/r9i can boot from the
-	// encrypted copy (this is the image actually used to launch VMs).
 	if err = a.stemcells.EnableNvmeSupport(imageId); err != nil {
 		a.cleanUp(imageId)
 		return "", bosherr.WrapError(err, "Failed to enable NvmeSupport on copied Alicloud Image")

--- a/src/bosh-alicloud-cpi/action/create_stemcell_test.go
+++ b/src/bosh-alicloud-cpi/action/create_stemcell_test.go
@@ -4,9 +4,47 @@
 package action
 
 import (
+	"bosh-alicloud-cpi/alicloud"
+	"bosh-alicloud-cpi/mock"
+	"fmt"
+	"os"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
+	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
+
+// nvmeStemcellManagerSpy wraps StemcellManagerMock and records whether
+// EnableNvmeSupport was called and with which image ID.
+type nvmeStemcellManagerSpy struct {
+	alicloud.StemcellManager
+	nvmeCalledWith []string
+	nvmeErr        error
+}
+
+func (s *nvmeStemcellManagerSpy) EnableNvmeSupport(imageId string) error {
+	s.nvmeCalledWith = append(s.nvmeCalledWith, imageId)
+	return s.nvmeErr
+}
+
+func (s *nvmeStemcellManagerSpy) CopyImage(args *ecs.CopyImageRequest) (string, error) {
+	return s.StemcellManager.CopyImage(args)
+}
+
+func newEncryptedCallerWithSpy(spy *nvmeStemcellManagerSpy, config alicloud.Config) Caller {
+	logger := boshlog.NewWriterLogger(boshlog.LevelWarn, os.Stderr)
+	mc := mock.NewTestContext(config)
+	services := Services{
+		Stemcells: spy,
+		Osses:     mock.NewOssManagerMock(mc),
+		Instances: mock.NewInstanceManagerMock(mc),
+		Disks:     mock.NewDiskManagerMock(mc),
+		Networks:  mock.NewNetworkManagerMock(mc),
+		Registry:  mock.NewRegistryMock(),
+	}
+	return NewCallerWithServices(config, logger, services)
+}
 
 var _ = Describe("create_stemcell", func() {
 	It("can create stemcell", func() {
@@ -97,3 +135,128 @@ var _ = Describe("create_stemcell", func() {
 		Expect(r.GetError()).NotTo(HaveOccurred())
 	})
 })
+
+var _ = Describe("create_stemcell EnableNvmeSupport", func() {
+	// stemcell arguments shared across cases — uses the image_id (region map) path so
+	// no real file I/O or OSS upload is needed.
+	const stemcellArgs = `[
+		"/var/vcap/data/tmp/director/stemcell/image",
+		{
+			"architecture": "x86_64",
+			"disk": "50",
+			"disk_format": "rawdisk",
+			"hypervisor": "kvm",
+			"image_id": {"cn-beijing": "m-2zehhdtfg22hq46reabf"},
+			"infrastructure": "alicloud",
+			"name": "bosh-alicloud-kvm-ubuntu-jammy-go_agent",
+			"os_distro": "ubuntu",
+			"os_type": "linux",
+			"version": "1.0"
+		}
+	]`
+
+	It("calls EnableNvmeSupport on the copied image when encryption is enabled", func() {
+		cfg := mustParseEncryptedConfig()
+		spy := &nvmeStemcellManagerSpy{
+			StemcellManager: mock.NewStemcellManagerMock(mock.NewTestContext(cfg)),
+		}
+		encryptedCaller := newEncryptedCallerWithSpy(spy, cfg)
+
+		r := encryptedCaller.Run([]byte(`{
+			"method": "create_stemcell",
+			"arguments": ` + stemcellArgs + `,
+			"context": {"director_uuid": "073eac6e-7a35-4a49-8c42-68988ea16ca7"}
+		}`))
+
+		Expect(r.GetError()).NotTo(HaveOccurred())
+		Expect(spy.nvmeCalledWith).To(HaveLen(1),
+			"EnableNvmeSupport should be called exactly once on the copied image")
+	})
+
+	It("does not call EnableNvmeSupport when encryption is disabled", func() {
+		spy := &nvmeStemcellManagerSpy{
+			StemcellManager: mock.NewStemcellManagerMock(mockContext),
+		}
+
+		// Use the global caller (no encryption) but swap in our spy via a local caller.
+		localCaller := newCallerWithSpy(spy)
+
+		r := localCaller.Run([]byte(`{
+			"method": "create_stemcell",
+			"arguments": ` + stemcellArgs + `,
+			"context": {"director_uuid": "073eac6e-7a35-4a49-8c42-68988ea16ca7"}
+		}`))
+
+		Expect(r.GetError()).NotTo(HaveOccurred())
+		Expect(spy.nvmeCalledWith).To(BeEmpty(),
+			"EnableNvmeSupport should not be called when encryption is disabled")
+	})
+
+	It("propagates an error from EnableNvmeSupport", func() {
+		cfg := mustParseEncryptedConfig()
+		spy := &nvmeStemcellManagerSpy{
+			StemcellManager: mock.NewStemcellManagerMock(mock.NewTestContext(cfg)),
+			nvmeErr:         fmt.Errorf("ModifyImageAttribute: forbidden"),
+		}
+		encryptedCaller := newEncryptedCallerWithSpy(spy, cfg)
+
+		r := encryptedCaller.Run([]byte(`{
+			"method": "create_stemcell",
+			"arguments": ` + stemcellArgs + `,
+			"context": {"director_uuid": "073eac6e-7a35-4a49-8c42-68988ea16ca7"}
+		}`))
+
+		Expect(r.GetError()).To(HaveOccurred())
+		Expect(r.GetError().Error()).To(ContainSubstring("ModifyImageAttribute: forbidden"))
+	})
+})
+
+// newCallerWithSpy builds a non-encrypted Caller with the given stemcell manager.
+func newCallerWithSpy(spy *nvmeStemcellManagerSpy) Caller {
+	logger := boshlog.NewWriterLogger(boshlog.LevelWarn, os.Stderr)
+	config, err := alicloud.NewConfigFromBytes(configForTest)
+	Expect(err).NotTo(HaveOccurred())
+	mc := mock.NewTestContext(config)
+	services := Services{
+		Stemcells: spy,
+		Osses:     mock.NewOssManagerMock(mc),
+		Instances: mock.NewInstanceManagerMock(mc),
+		Disks:     mock.NewDiskManagerMock(mc),
+		Networks:  mock.NewNetworkManagerMock(mc),
+		Registry:  mock.NewRegistryMock(),
+	}
+	return NewCallerWithServices(config, logger, services)
+}
+
+func mustParseEncryptedConfig() alicloud.Config {
+	encryptedConfigBytes := []byte(`{
+		"cloud": {
+			"plugin": "alicloud",
+			"properties": {
+				"alicloud": {
+					"region": "cn-beijing",
+					"availability_zone": "cn-beijing-a",
+					"access_key_id": "---",
+					"access_key_secret": "---",
+					"encrypted": true
+				},
+				"registry": {
+					"user": "registry", "password": "registry",
+					"protocol": "http", "address": "127.0.0.1", "port": 25777
+				},
+				"agent": {
+					"ntp": ["0.pool.ntp.org"],
+					"mbus": "http://mbus:mbus@0.0.0.0:6868",
+					"blobstore": {
+						"provider": "dav",
+						"options": {"endpoint": "http://10.0.0.2:25250", "user": "agent", "password": "agent-password"}
+					}
+				}
+			}
+		}
+	}`)
+	config, err := alicloud.NewConfigFromBytes(encryptedConfigBytes)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(config.Validate()).To(Succeed())
+	return config
+}

--- a/src/bosh-alicloud-cpi/alicloud/stemcell_manager.go
+++ b/src/bosh-alicloud-cpi/alicloud/stemcell_manager.go
@@ -178,9 +178,7 @@ func (a StemcellManagerImpl) OpenLocalFile(path string) (*os.File, error) {
 }
 
 // EnableNvmeSupport sets the Features.NvmeSupport=supported attribute on an existing
-// ECS image. Required for c9i/g9i/r9i (gen-3) instance families which only accept
-// NVMe-capable images. Upstream sets this on ImportImage but not on CopyImage; we
-// apply it post-create as a uniform safety net so encrypted-copy images also get it.
+// ECS image.
 func (a StemcellManagerImpl) EnableNvmeSupport(imageId string) error {
 	client, err := a.config.NewEcsClient("")
 	if err != nil {

--- a/src/bosh-alicloud-cpi/alicloud/stemcell_manager.go
+++ b/src/bosh-alicloud-cpi/alicloud/stemcell_manager.go
@@ -29,6 +29,7 @@ type StemcellManager interface {
 	DeleteStemcell(id string) error
 	ImportImage(args *ecs.ImportImageRequest) (string, error)
 	CopyImage(args *ecs.CopyImageRequest) (string, error)
+	EnableNvmeSupport(imageId string) error
 	OpenLocalFile(path string) (*os.File, error)
 	WaitForImageReady(id string) error
 }
@@ -174,6 +175,28 @@ func (a StemcellManagerImpl) CopyImage(args *ecs.CopyImageRequest) (string, erro
 
 func (a StemcellManagerImpl) OpenLocalFile(path string) (*os.File, error) {
 	return os.Open(path)
+}
+
+// EnableNvmeSupport sets the Features.NvmeSupport=supported attribute on an existing
+// ECS image. Required for c9i/g9i/r9i (gen-3) instance families which only accept
+// NVMe-capable images. Upstream sets this on ImportImage but not on CopyImage; we
+// apply it post-create as a uniform safety net so encrypted-copy images also get it.
+func (a StemcellManagerImpl) EnableNvmeSupport(imageId string) error {
+	client, err := a.config.NewEcsClient("")
+	if err != nil {
+		return err
+	}
+
+	args := ecs.CreateModifyImageAttributeRequest()
+	args.ImageId = imageId
+	args.Features = ecs.ModifyImageAttributeFeatures{NvmeSupport: "supported"}
+
+	if _, err := client.ModifyImageAttribute(args); err != nil {
+		return bosherr.WrapErrorf(err, "Failed to enable NvmeSupport on Alicloud Image '%s'", imageId)
+	}
+
+	a.logger.Info(AlicloudImageServiceTag, "Enabled NvmeSupport on Alicloud Image '%s'", imageId)
+	return nil
 }
 
 // import image from oss may take >=15min

--- a/src/bosh-alicloud-cpi/mock/stemcell_manager_mock.go
+++ b/src/bosh-alicloud-cpi/mock/stemcell_manager_mock.go
@@ -55,6 +55,10 @@ func (a StemcellManagerMock) CopyImage(args *ecs.CopyImageRequest) (string, erro
 	return id, nil
 }
 
+func (a StemcellManagerMock) EnableNvmeSupport(imageId string) error {
+	return nil
+}
+
 func (a StemcellManagerMock) OpenLocalFile(path string) (*os.File, error) {
 	return nil, nil
 }


### PR DESCRIPTION
# Problem

AliCloud 9th-generation instance types (c9i, g9i, r9i) require stemcell images to have Features.NvmeSupport=supported. Without it, VM creation fails with:

InvalidParameter.NotMatch: The specified instance type requires NVMe but the image does not support NVMe.

Upstream v57.0.0 already sets this flag during ImportImage via QueryParams. However, when alicloud.encrypted: true is set in the CPI config, create_stemcell runs CopyImage after import to produce an encrypted copy — and that copy is the image actually used to launch VMs.

CopyImage does not propagate Features from the source image. Passing Features.NvmeSupport via QueryParams on CopyImage (mirroring the import approach) is silently ignored by the API. The copied image consistently comes out with NvmeSupport: unsupported, so any c9i/g9i/r9i VM launched in an encrypted-image environment fails.

# Solution

Added EnableNvmeSupport(imageId string) error to StemcellManager. It calls ModifyImageAttribute with Features.NvmeSupport=supported on the image after it is created. This is invoked in create_stemcell.go after copyImage completes.

ModifyImageAttribute is the only supported path for setting this attribute on an existing image — the CopyImage API has no equivalent parameter.

## Changes

- alicloud/stemcell_manager.go — adds EnableNvmeSupport to the StemcellManager interface and implements it on StemcellManagerImpl
- action/create_stemcell.go — calls EnableNvmeSupport after copyImage succeeds; on failure, cleans up the image and returns an error
- mock/stemcell_manager_mock.go — no-op stub to satisfy the interface

## Tests

- Added a spy stemcell manager in create_stemcell_test.go to verify EnableNvmeSupport is called exactly once after a copy (encrypted path) and not called when encryption is disabled
- Added an error propagation test: if EnableNvmeSupport returns an error, create_stemcell fails and the copied image is cleaned up
- No-op mock stub keeps all existing tests green
- Verified against a real ECS image using the same SDK call: Features.NvmeSupport flips from unsupported to supported
- Validated end-to-end: c9i VM creation that previously failed with InvalidParameter.NotMatch now succeeds