### PR TITLE
Prepare release v58.0.0 and fix promote-candidate pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 
 All releases of the BOSH CPI for Alibaba Cloud will be documented in this file.
+## 58.0.0 (Unreleased)
+
+FIXES:
+
+- Fixed NVMe support not being propagated when copying encrypted stemcell images ([#204](https://github.com/cloudfoundry/bosh-alicloud-cpi-release/pull/204))
+  - `CopyImage` does not inherit `Features.NvmeSupport` from the source image; now explicitly set via `ModifyImageAttribute` after copy
+
 ## 57.0.0 (May 28, 2026)
 
 FEATURES:

--- a/ci/tasks/promote-candidate.sh
+++ b/ci/tasks/promote-candidate.sh
@@ -43,7 +43,7 @@ EOF
   git diff | cat
   git add .
 
-  git config --global user.email guimin.hgm@alibaba-inc.com
-  git config --global user.name xiaozhu36
+  git config --global user.email kangtai.kang@alibaba-inc.com
+  git config --global user.name ali-tkang
   git commit -m "Bump Alibaba Cloud cpi/$integer_version"
 popd


### PR DESCRIPTION
## Summary

- Add `## 58.0.0 (Unreleased)` section to CHANGELOG.md with PR #204 release notes
- Update git committer in `promote-candidate.sh` to current maintainer

## Why

v57.0.0 was released manually via PR #203, which skipped the `promote-candidate` pipeline. As a result, the `(Unreleased)` placeholder that `promote-candidate.sh` depends on was never inserted into CHANGELOG.md.

Without this fix, the `sed` command on line 36 of `promote-candidate.sh` runs with an empty line number address, causing it to insert text before **every line** in the file and corrupt the entire CHANGELOG.

## Test plan

- [ ] Verify `promote-candidate` job runs successfully after merging
- [ ] Verify CHANGELOG.md is correctly updated with the release date

🤖 Generated with [Claude Code](https://claude.com/claude-code)