### PR TITLE
Finalize release v58.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Change Log
 
 All releases of the BOSH CPI for Alibaba Cloud will be documented in this file.
-## 58.0.0 (Unreleased)
+## 59.0.0 (Unreleased)
+
+## 58.0.0 (June 10, 2026)
 
 FIXES:
 

--- a/releases/bosh-alicloud-cpi/bosh-alicloud-cpi-58.0.0.yml
+++ b/releases/bosh-alicloud-cpi/bosh-alicloud-cpi-58.0.0.yml
@@ -1,0 +1,28 @@
+name: bosh-alicloud-cpi
+version: 58.0.0
+commit_hash: 3bba96c
+uncommitted_changes: true
+jobs:
+- name: alicloud_cpi
+  version: f53ccfc4120077aeb67b1bb99bade9e7b95625db905dedf5f669d7aaf2f0eeda
+  fingerprint: f53ccfc4120077aeb67b1bb99bade9e7b95625db905dedf5f669d7aaf2f0eeda
+  sha1: sha256:959c4dffd0bc57c950e08d2663ab7fde9322ad5c49382ebe50db689abbaa1ffc
+  packages:
+  - bosh-alicloud-cpi
+packages:
+- name: bosh-alicloud-cpi
+  version: 0e9c99f3a214d3efae483c683fe7590036d2a15d1036d5d2fd5e3ccb2063eee4
+  fingerprint: 0e9c99f3a214d3efae483c683fe7590036d2a15d1036d5d2fd5e3ccb2063eee4
+  sha1: sha256:973acaf238a838667dd2f2e4edec99e2accc9f6e2f5f7c561e43b3c840e95653
+  dependencies:
+  - golang
+- name: golang
+  version: d5ed0c6b23b5604dcdc9765d33c81e1ed1376732bdfe88065d373aa56b4f9b29
+  fingerprint: d5ed0c6b23b5604dcdc9765d33c81e1ed1376732bdfe88065d373aa56b4f9b29
+  sha1: sha256:f7e36f3f2d5357e7a8ae7090411b8b784d72a441738473d4c132b7e9a74d86e0
+  dependencies: []
+license:
+  version: d35e32db8d971404d5cca86a46140fabed166034a22aaa007b4a3948c758a934
+  fingerprint: d35e32db8d971404d5cca86a46140fabed166034a22aaa007b4a3948c758a934
+  sha1: sha256:12c7e344c47d4c8c1cbe31613255b361970e74773437eec15e985ba9eedc4d50
+no_compression: false

--- a/releases/bosh-alicloud-cpi/index.yml
+++ b/releases/bosh-alicloud-cpi/index.yml
@@ -53,6 +53,8 @@ builds:
     version: "4"
   d3d3532a-124c-4e48-50da-6d8663adafd1:
     version: 28.0.0
+  e6cf3a87-373e-40b6-409f-3670b5e694d1:
+    version: 58.0.0
   e9e25de4-2cea-47fd-6b73-9d054f9e0ddc:
     version: "11"
 format-version: "2"


### PR DESCRIPTION
## Summary

- Finalize BOSH release v58.0.0
- Update CHANGELOG.md with v58.0.0 release date and v59.0.0 (Unreleased) placeholder
- Generated release manifest and updated release index

### Included in this release:
- Fixed NVMe support not being propagated when copying encrypted stemcell images ([#204](https://github.com/cloudfoundry/bosh-alicloud-cpi-release/pull/204))
- Updated promote-candidate pipeline committer info ([#205](https://github.com/cloudfoundry/bosh-alicloud-cpi-release/pull/205))