### PR TITLE
Add NVMe support configuration based on stemcell parameter

### DIFF
--- a/src/bosh-alicloud-cpi/action/create_stemcell.go
+++ b/src/bosh-alicloud-cpi/action/create_stemcell.go
@@ -38,6 +38,7 @@ type StemcellProps struct {
 	diskGB          int
 	Hypervisor      string `json:"hypervisor"`
 	Name            string `json:"name"`
+	NvmeSupport     string `json:"nvme_support"`
 	OsDistro        string `json:"os_distro"`
 	OsType          string `json:"os_type"`
 	//RootDeviceName string 	`json:"root_device_name"`
@@ -179,7 +180,9 @@ func (a CreateStemcellMethod) importImage(props StemcellProps) (string, error) {
 		args.Platform = formatImagePlatform(strings.ToLower(props.OsDistro))
 	}
 	args.Description = props.Description
-	args.QueryParams["Features.NvmeSupport"] = "supported"
+	if props.NvmeSupport == "supported" {
+		args.QueryParams["Features.NvmeSupport"] = "supported"
+	}
 
 	devices := []ecs.ImportImageDiskDeviceMapping{
 		device,
@@ -233,9 +236,12 @@ func (a CreateStemcellMethod) copyImage(stemcellId string, props StemcellProps) 
 	}
 
 	// CopyImage does not propagate Features.NvmeSupport from the source image.
-	if err = a.stemcells.EnableNvmeSupport(imageId); err != nil {
-		a.cleanUp(imageId)
-		return "", bosherr.WrapError(err, "Failed to enable NvmeSupport on copied Alicloud Image")
+	// Only call EnableNvmeSupport when the stemcell declares nvme_support=supported.
+	if props.NvmeSupport == "supported" {
+		if err = a.stemcells.EnableNvmeSupport(imageId); err != nil {
+			a.cleanUp(imageId)
+			return "", bosherr.WrapError(err, "Failed to enable NvmeSupport on copied Alicloud Image")
+		}
 	}
 
 	a.Logger.Debug(alicloud.AlicloudImageServiceTag, "Copy Alicloud Image %s success", imageId)

--- a/src/bosh-alicloud-cpi/action/create_stemcell_test.go
+++ b/src/bosh-alicloud-cpi/action/create_stemcell_test.go
@@ -139,7 +139,24 @@ var _ = Describe("create_stemcell", func() {
 var _ = Describe("create_stemcell EnableNvmeSupport", func() {
 	// stemcell arguments shared across cases — uses the image_id (region map) path so
 	// no real file I/O or OSS upload is needed.
-	const stemcellArgs = `[
+	const stemcellArgsWithNvme = `[
+		"/var/vcap/data/tmp/director/stemcell/image",
+		{
+			"architecture": "x86_64",
+			"disk": "50",
+			"disk_format": "rawdisk",
+			"hypervisor": "kvm",
+			"image_id": {"cn-beijing": "m-2zehhdtfg22hq46reabf"},
+			"infrastructure": "alicloud",
+			"name": "bosh-alicloud-kvm-ubuntu-jammy-go_agent",
+			"os_distro": "ubuntu",
+			"os_type": "linux",
+			"nvme_support": "supported",
+			"version": "1.0"
+		}
+	]`
+
+	const stemcellArgsWithoutNvme = `[
 		"/var/vcap/data/tmp/director/stemcell/image",
 		{
 			"architecture": "x86_64",
@@ -155,7 +172,7 @@ var _ = Describe("create_stemcell EnableNvmeSupport", func() {
 		}
 	]`
 
-	It("calls EnableNvmeSupport on the copied image when encryption is enabled", func() {
+	It("calls EnableNvmeSupport on the copied image when encryption is enabled and nvme_support=supported", func() {
 		cfg := mustParseEncryptedConfig()
 		spy := &nvmeStemcellManagerSpy{
 			StemcellManager: mock.NewStemcellManagerMock(mock.NewTestContext(cfg)),
@@ -164,7 +181,7 @@ var _ = Describe("create_stemcell EnableNvmeSupport", func() {
 
 		r := encryptedCaller.Run([]byte(`{
 			"method": "create_stemcell",
-			"arguments": ` + stemcellArgs + `,
+			"arguments": ` + stemcellArgsWithNvme + `,
 			"context": {"director_uuid": "073eac6e-7a35-4a49-8c42-68988ea16ca7"}
 		}`))
 
@@ -183,13 +200,31 @@ var _ = Describe("create_stemcell EnableNvmeSupport", func() {
 
 		r := localCaller.Run([]byte(`{
 			"method": "create_stemcell",
-			"arguments": ` + stemcellArgs + `,
+			"arguments": ` + stemcellArgsWithNvme + `,
 			"context": {"director_uuid": "073eac6e-7a35-4a49-8c42-68988ea16ca7"}
 		}`))
 
 		Expect(r.GetError()).NotTo(HaveOccurred())
 		Expect(spy.nvmeCalledWith).To(BeEmpty(),
 			"EnableNvmeSupport should not be called when encryption is disabled")
+	})
+
+	It("does not call EnableNvmeSupport when nvme_support is absent from stemcell props", func() {
+		cfg := mustParseEncryptedConfig()
+		spy := &nvmeStemcellManagerSpy{
+			StemcellManager: mock.NewStemcellManagerMock(mock.NewTestContext(cfg)),
+		}
+		encryptedCaller := newEncryptedCallerWithSpy(spy, cfg)
+
+		r := encryptedCaller.Run([]byte(`{
+			"method": "create_stemcell",
+			"arguments": ` + stemcellArgsWithoutNvme + `,
+			"context": {"director_uuid": "073eac6e-7a35-4a49-8c42-68988ea16ca7"}
+		}`))
+
+		Expect(r.GetError()).NotTo(HaveOccurred())
+		Expect(spy.nvmeCalledWith).To(BeEmpty(),
+			"EnableNvmeSupport should not be called when nvme_support is not declared in stemcell props")
 	})
 
 	It("propagates an error from EnableNvmeSupport", func() {
@@ -202,7 +237,7 @@ var _ = Describe("create_stemcell EnableNvmeSupport", func() {
 
 		r := encryptedCaller.Run([]byte(`{
 			"method": "create_stemcell",
-			"arguments": ` + stemcellArgs + `,
+			"arguments": ` + stemcellArgsWithNvme + `,
 			"context": {"director_uuid": "073eac6e-7a35-4a49-8c42-68988ea16ca7"}
 		}`))
 


### PR DESCRIPTION
## Gate NVMe support enablement on stemcell nvme_support cloud property

AliCloud instance families (c9i, g9i, r9i) require stemcell images with `Features.NvmeSupport=supported`. The CPI was previously enabling this unconditionally on every stemcell import and copy, regardless of whether the stemcell declared NVMe support.

This change reads the `nvme_support` field from the stemcell's cloud_properties (written by the stemcell builder at build time) and only enables NVMe support when its value is "supported". Stemcells built without this property are unaffected.

## Changes

- action/create_stemcell.go
    - Added NvmeSupport string `json:"nvme_support"` to `StemcellProps`
    - `importImage`: `Features.NvmeSupport=supported` is only added to the ImportImage request when `props.NvmeSupport == "supported"`
    - `copyImage`: `EnableNvmeSupport` (the `ModifyImageAttribute` call required because `CopyImage` does not propagate the flag from the source image) is only invoked when `props.NvmeSupport == "supported"`
- action/create_stemcell_test.go
    - Split test fixtures into `stemcellArgsWithNvme` and `stemcellArgsWithoutNvme`
    - Added test: encrypted config + no `nvme_support` property → `EnableNvmeSupport` is not called

## Dependencies

Requires a stemcell built from the companion `bosh-linux-stemcell-builder` change that adds ``"nvme_support": "supported"` to the AliCloud infrastructure definition. Stemcells built without that change will continue to work — NVMe support simply will not be enabled at import/copy time.