### PR TITLE
Resolve ephemeral disk to NVMe by-id path on NVMe-capable instance types

### DIFF
--- a/src/bosh-alicloud-cpi/action/actions_suite_test.go
+++ b/src/bosh-alicloud-cpi/action/actions_suite_test.go
@@ -6,6 +6,7 @@ package action
 import (
 	"bosh-alicloud-cpi/alicloud"
 	"bosh-alicloud-cpi/mock"
+	"bosh-alicloud-cpi/registry"
 	"os"
 	"testing"
 
@@ -21,6 +22,7 @@ func TestActions(t *testing.T) {
 
 var caller Caller
 var mockContext mock.TestContext
+var registryMock registry.Client
 
 var configForTest = []byte(`{
     "cloud": {
@@ -65,13 +67,14 @@ var _ = BeforeSuite(func() {
 	logger := boshlog.NewWriterLogger(boshlog.LevelWarn, os.Stderr)
 
 	mockContext = mock.NewTestContext(config)
+	registryMock = mock.NewRegistryMock()
 	services := Services{
 		Stemcells: mock.NewStemcellManagerMock(mockContext),
 		Osses:     mock.NewOssManagerMock(mockContext),
 		Instances: mock.NewInstanceManagerMock(mockContext),
 		Disks:     mock.NewDiskManagerMock(mockContext),
 		Networks:  mock.NewNetworkManagerMock(mockContext),
-		Registry:  mock.NewRegistryMock(),
+		Registry:  registryMock,
 	}
 
 	caller = NewCallerWithServices(config, logger, services)

--- a/src/bosh-alicloud-cpi/action/attach_disk.go
+++ b/src/bosh-alicloud-cpi/action/attach_disk.go
@@ -69,10 +69,17 @@ func (a AttachDiskMethod) attach(vmCID apiv1.VMCID, diskCID apiv1.DiskCID, cpiVe
 		switch alicloud.DiskStatus(disk.Status) {
 		case alicloud.DiskStatusInUse:
 			inst, er := a.instances.GetInstance(instCid)
+			var derr error
 			if er == nil {
-				device = a.disks.GetDiskPath(disk.Device, diskCid, inst.InstanceType, alicloud.DiskCategory(disk.Category))
+				device, derr = a.disks.GetDiskPath(disk.Device, diskCid, inst.InstanceType, alicloud.DiskCategory(disk.Category))
 			} else {
-				device = a.disks.GetDiskPath(disk.Device, diskCid, "", alicloud.DiskCategory(disk.Category))
+				device, derr = a.disks.GetDiskPath(disk.Device, diskCid, "", alicloud.DiskCategory(disk.Category))
+			}
+			// The disk is already attached; a resolution failure is non-fatal here
+			// (unlike create_vm's ephemeral path). Log it and proceed with the
+			// best-effort path GetDiskPath returned.
+			if derr != nil {
+				a.Logger.Warn("AttachDisk", "resolve disk path for %s on %s failed, using best-effort path %s: %s", diskCid, instCid, device, derr)
 			}
 			return true, nil
 		case alicloud.DiskStatusAvailable:

--- a/src/bosh-alicloud-cpi/action/create_vm.go
+++ b/src/bosh-alicloud-cpi/action/create_vm.go
@@ -294,11 +294,14 @@ func (a CreateVMMethod) createVM(
 	// Resolve the ephemeral disk path. For NVMe-capable instance types (c9i/g9i/r9i/...),
 	// the legacy /dev/vdb path does not exist; the agent must use /dev/disk/by-id/nvme-...
 	// We can only do this after VM creation because we need the data disk's CID.
+	//
+	// On NVMe instances, leaving the legacy path would cause the agent to loop forever
+	// waiting for /dev/vdb and the deploy would only fail after the 600s agent-ping timeout.
+	// Fail fast here and let the existing post-CreateInstance cleanup path delete the VM.
 	if disks.EphemeralDisk.sizeGB > 0 {
 		attachedDisks, derr := a.disks.GetDisks(instCid)
-		if derr != nil {
-			a.Logger.Warn("create_vm", "GetDisks after create failed for %s: %v - leaving ephemeral path as %s", instCid, derr, disks.EphemeralDisk.path)
-		} else {
+		if derr == nil {
+			found := false
 			for _, d := range attachedDisks {
 				if d.Type == "data" {
 					disks.EphemeralDisk.path = a.disks.GetDiskPath(
@@ -307,9 +310,34 @@ func (a CreateVMMethod) createVM(
 						instProps.InstanceType,
 						alicloud.DiskCategory(d.Category),
 					)
+					found = true
 					break
 				}
 			}
+			if !found {
+				derr = bosherr.Errorf("no data disk found attached to instance %s after create", instCid)
+			}
+		}
+		if derr != nil {
+			eniIds := a.instances.GetAttachedNetworkInterfaceIds(instCid)
+			var err2 error
+			for retry := 0; retry < 10; retry++ {
+				err2 = a.instances.ChangeInstanceStatus(instCid, alicloud.Deleted, func(status alicloud.InstanceStatus) (bool, error) {
+					switch status {
+					case alicloud.Running, alicloud.Stopped:
+						return false, a.instances.DeleteInstance(instCid)
+					case alicloud.Deleted:
+						return true, a.instances.CleanupInstanceNetworkInterfaces(instCid, eniIds)
+					default:
+						return false, nil
+					}
+				})
+				if err2 == nil {
+					return apiv1.NewVMCID(instCid), nil, bosherr.WrapErrorf(derr, "resolve ephemeral disk path for %s failed and the vm has been deleted.", instCid)
+				}
+				time.Sleep(5 * time.Second)
+			}
+			return apiv1.NewVMCID(instCid), nil, bosherr.WrapErrorf(derr, "resolve ephemeral disk path for %s failed and then delete it timeout: %v", instCid, err2)
 		}
 	}
 

--- a/src/bosh-alicloud-cpi/action/create_vm.go
+++ b/src/bosh-alicloud-cpi/action/create_vm.go
@@ -291,6 +291,28 @@ func (a CreateVMMethod) createVM(
 		return apiv1.VMCID{}, nil, bosherr.WrapErrorf(err, "wait %s to STOPPED failed and then delete it timeout: %v", instCid, err2)
 	}
 
+	// Resolve the ephemeral disk path. For NVMe-capable instance types (c9i/g9i/r9i/...),
+	// the legacy /dev/vdb path does not exist; the agent must use /dev/disk/by-id/nvme-...
+	// We can only do this after VM creation because we need the data disk's CID.
+	if disks.EphemeralDisk.sizeGB > 0 {
+		attachedDisks, derr := a.disks.GetDisks(instCid)
+		if derr != nil {
+			a.Logger.Warn("create_vm", "GetDisks after create failed for %s: %v - leaving ephemeral path as %s", instCid, derr, disks.EphemeralDisk.path)
+		} else {
+			for _, d := range attachedDisks {
+				if d.Type == "data" {
+					disks.EphemeralDisk.path = a.disks.GetDiskPath(
+						disks.EphemeralDisk.path,
+						d.DiskId,
+						instProps.InstanceType,
+						alicloud.DiskCategory(d.Category),
+					)
+					break
+				}
+			}
+		}
+	}
+
 	agentSettings := registry.AgentSettings{
 		AgentID:   agentID.AsString(),
 		Blobstore: a.Config.Agent.Blobstore.AsRegistrySettings(),

--- a/src/bosh-alicloud-cpi/action/create_vm.go
+++ b/src/bosh-alicloud-cpi/action/create_vm.go
@@ -301,7 +301,7 @@ func (a CreateVMMethod) createVM(
 			found := false
 			for _, d := range attachedDisks {
 				if d.Type == "data" {
-					disks.EphemeralDisk.path = a.disks.GetDiskPath(
+					disks.EphemeralDisk.path, derr = a.disks.GetDiskPath(
 						disks.EphemeralDisk.path,
 						d.DiskId,
 						instProps.InstanceType,
@@ -311,7 +311,7 @@ func (a CreateVMMethod) createVM(
 					break
 				}
 			}
-			if !found {
+			if derr == nil && !found {
 				derr = bosherr.Errorf("no data disk found attached to instance %s after create", instCid)
 			}
 		}

--- a/src/bosh-alicloud-cpi/action/create_vm.go
+++ b/src/bosh-alicloud-cpi/action/create_vm.go
@@ -291,13 +291,10 @@ func (a CreateVMMethod) createVM(
 		return apiv1.VMCID{}, nil, bosherr.WrapErrorf(err, "wait %s to STOPPED failed and then delete it timeout: %v", instCid, err2)
 	}
 
-	// Resolve the ephemeral disk path. For NVMe-capable instance types (c9i/g9i/r9i/...),
-	// the legacy /dev/vdb path does not exist; the agent must use /dev/disk/by-id/nvme-...
-	// We can only do this after VM creation because we need the data disk's CID.
-	//
-	// On NVMe instances, leaving the legacy path would cause the agent to loop forever
-	// waiting for /dev/vdb and the deploy would only fail after the 600s agent-ping timeout.
-	// Fail fast here and let the existing post-CreateInstance cleanup path delete the VM.
+	// Resolve the ephemeral disk path after VM creation (we need the data disk CID).
+	// NVMe instance types use /dev/disk/by-id/nvme-... instead of the legacy /dev/vdb.
+	// If unresolved, the agent would hang until the 600s ping timeout, so fail fast
+	// and cleanup by deleting the VM.
 	if disks.EphemeralDisk.sizeGB > 0 {
 		attachedDisks, derr := a.disks.GetDisks(instCid)
 		if derr == nil {

--- a/src/bosh-alicloud-cpi/action/create_vm_test.go
+++ b/src/bosh-alicloud-cpi/action/create_vm_test.go
@@ -286,4 +286,92 @@ var _ = Describe("create_vm", func() {
 		r := caller.Run(in)
 		Expect(r.GetError()).NotTo(HaveOccurred())
 	})
+
+	Context("ephemeral disk path resolution", func() {
+		// buildCreateVM returns a create_vm request for the given instance type with
+		// an ephemeral disk, so the mock attaches a "data" disk that create_vm then
+		// resolves a device path for.
+		buildCreateVM := func(instanceType string) []byte {
+			return mock.NewBuilder(`{
+				"method": "create_vm",
+				"arguments": [
+					"243bf6fc-8f26-4aef-b40f-824763fcdfa2",
+					"m-2zehhdtfg22hq46reabf",
+					{
+						"instance_type": "` + instanceType + `",
+						"ephemeral_disk": { "size": "40_960", "type": "cloud_efficiency" }
+					},
+					{
+						"cf1": {
+							"type": "manual",
+							"ip": "10.0.16.109",
+							"netmask": "255.255.240.0",
+							"cloud_properties": {
+							"security_group_ids": ["sg-2ze2ct08gslmnwyv8c1k"],
+							"vswitch_id": "vpc-2ze3owai4kbkv2yf6nivg"
+						},
+							"default": ["dns", "gateway"],
+							"dns": ["10.0.16.2"],
+							"gateway": "10.0.16.1"
+						}
+					},
+					[],
+					{ "bosh": { "group": "g" } }
+				],
+				"context": { "director_uuid": "879e2edf-a9c4-4d2e-be8c-6b23dc530008" }
+			}`).ToBytes()
+		}
+
+		ephemeralPathFor := func(r CpiResponse) string {
+			cid := r.GetResultString()
+			settings, err := registryMock.Fetch(cid)
+			Expect(err).NotTo(HaveOccurred())
+			return settings.Disks.Ephemeral
+		}
+
+		AfterEach(func() {
+			delete(mockContext.Flags, "failGetDisks")
+			delete(mockContext.Flags, "failDiskPath")
+			delete(mockContext.Flags, "noDataDisk")
+		})
+
+		It("resolves the NVMe by-id path on an NVMe-capable instance type", func() {
+			r := caller.Run(buildCreateVM("ecs.c9i.xlarge"))
+			Expect(r.GetError()).NotTo(HaveOccurred())
+			Expect(ephemeralPathFor(r)).To(HavePrefix("/dev/disk/by-id/nvme-Alibaba_Cloud_Elastic_Block_Storage_"))
+		})
+
+		It("resolves the virtio by-id path on a non-NVMe instance type", func() {
+			r := caller.Run(buildCreateVM("ecs.n4.xlarge"))
+			Expect(r.GetError()).NotTo(HaveOccurred())
+			Expect(ephemeralPathFor(r)).To(HavePrefix("/dev/disk/by-id/virtio-"))
+		})
+
+		It("fails and deletes the VM when GetDisks fails", func() {
+			mockContext.Flags["failGetDisks"] = true
+			before := len(mockContext.Instances)
+
+			r := caller.Run(buildCreateVM("ecs.c9i.xlarge"))
+			Expect(r.GetError()).To(HaveOccurred())
+			Expect(mockContext.Instances).To(HaveLen(before), "the created instance should have been deleted")
+		})
+
+		It("fails and deletes the VM when path resolution fails", func() {
+			mockContext.Flags["failDiskPath"] = true
+			before := len(mockContext.Instances)
+
+			r := caller.Run(buildCreateVM("ecs.c9i.xlarge"))
+			Expect(r.GetError()).To(HaveOccurred())
+			Expect(mockContext.Instances).To(HaveLen(before), "the created instance should have been deleted")
+		})
+
+		It("fails and deletes the VM when no data disk is attached after create", func() {
+			mockContext.Flags["noDataDisk"] = true
+			before := len(mockContext.Instances)
+
+			r := caller.Run(buildCreateVM("ecs.c9i.xlarge"))
+			Expect(r.GetError()).To(HaveOccurred())
+			Expect(mockContext.Instances).To(HaveLen(before), "the created instance should have been deleted")
+		})
+	})
 })

--- a/src/bosh-alicloud-cpi/alicloud/disk_manager.go
+++ b/src/bosh-alicloud-cpi/alicloud/disk_manager.go
@@ -46,7 +46,7 @@ type DiskManager interface {
 	WaitForDiskStatus(diskCid string, toStatus DiskStatus) (string, error)
 	ChangeDiskStatus(cid string, toStatus DiskStatus, checkFunc func(*ecs.Disk) (bool, error)) error
 
-	GetDiskPath(path, diskId, instanceType string, category DiskCategory) string
+	GetDiskPath(path, diskId, instanceType string, category DiskCategory) (string, error)
 }
 
 type DiskManagerImpl struct {
@@ -372,17 +372,24 @@ func AmendDiskPath(path string, category DiskCategory) string {
 	return path
 }
 
-func (a DiskManagerImpl) GetDiskPath(path, diskId, instanceType string, category DiskCategory) string {
+// GetDiskPath resolves the device path the agent should use for a disk. For
+// NVMe-capable instance types it returns the /dev/disk/by-id/nvme-... path; for
+// other types the /dev/disk/by-id/virtio-... path. The returned string is always
+// a usable best-effort path (the amended input path when resolution can't run),
+// but a non-nil error means the NVMe-vs-virtio determination failed and the path
+// may be wrong — callers on the create_vm hot path must treat that as fatal, since
+// a wrong path leaves the agent hanging until the 600s ping timeout.
+func (a DiskManagerImpl) GetDiskPath(path, diskId, instanceType string, category DiskCategory) (string, error) {
 	amendPath := AmendDiskPath(path, category)
 
 	if instanceType == "" || diskId == "" {
-		return amendPath
+		return amendPath, nil
 	}
 
 	conn, err := a.config.EcsTeaClient("")
 	if err != nil {
 		a.log("EcsTeaClient", err, nil, "")
-		return amendPath
+		return amendPath, err
 	}
 
 	invoker := NewInvoker()
@@ -431,9 +438,10 @@ func (a DiskManagerImpl) GetDiskPath(path, diskId, instanceType string, category
 	})
 	if err != nil {
 		a.log(action, err, queries, "")
+		return amendPath, err
 	}
 
-	return amendPath
+	return amendPath, nil
 }
 
 func DescribeDisks(client *ecs.Client, diskId string) (disk *ecs.Disk, err error) {

--- a/src/bosh-alicloud-cpi/mock/context.go
+++ b/src/bosh-alicloud-cpi/mock/context.go
@@ -23,6 +23,12 @@ type TestContext struct {
 	OssObjects        map[string]string
 	Snapshots         map[string]string
 	NetworkInterfaces map[string]*ecs.NetworkInterface
+
+	// Flags is a shared failure-injection map for tests. It's a map (reference
+	// type) so mutations on the suite-level TestContext are visible to the mocks,
+	// which each hold a by-value copy of the struct but share the same map header.
+	// Recognized keys: "failGetDisks", "failDiskPath".
+	Flags map[string]bool
 }
 
 func NewTestContext(config alicloud.Config) TestContext {
@@ -34,6 +40,7 @@ func NewTestContext(config alicloud.Config) TestContext {
 		Buckets:    make(map[string]*oss.Bucket),
 		OssObjects: make(map[string]string),
 		Snapshots:  make(map[string]string),
+		Flags:      make(map[string]bool),
 	}
 }
 

--- a/src/bosh-alicloud-cpi/mock/disk_manager_mock.go
+++ b/src/bosh-alicloud-cpi/mock/disk_manager_mock.go
@@ -197,6 +197,6 @@ func (a DiskManagerMock) ChangeDiskStatus(cid string, toStatus alicloud.DiskStat
 	}
 }
 
-func (a DiskManagerMock) GetDiskPath(path, diskId, instanceType string, category alicloud.DiskCategory) string {
-	return path
+func (a DiskManagerMock) GetDiskPath(path, diskId, instanceType string, category alicloud.DiskCategory) (string, error) {
+	return path, nil
 }

--- a/src/bosh-alicloud-cpi/mock/disk_manager_mock.go
+++ b/src/bosh-alicloud-cpi/mock/disk_manager_mock.go
@@ -7,6 +7,7 @@ import (
 	"bosh-alicloud-cpi/alicloud"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 )
@@ -24,6 +25,9 @@ func NewDiskManagerMock(mc TestContext) alicloud.DiskManager {
 }
 
 func (a DiskManagerMock) GetDisks(instCid string) ([]ecs.Disk, error) {
+	if a.mc.Flags["failGetDisks"] {
+		return nil, fmt.Errorf("GetDisks injected failure (mock) for %s", instCid)
+	}
 	r := []ecs.Disk{}
 	for _, d := range a.mc.Disks {
 		if d.InstanceId == instCid {
@@ -197,6 +201,24 @@ func (a DiskManagerMock) ChangeDiskStatus(cid string, toStatus alicloud.DiskStat
 	}
 }
 
+// GetDiskPath mimics the real resolution: NVMe-capable instance types (the mock
+// treats any type containing "9i", e.g. ecs.c9i.*, as NVMe) resolve to the
+// nvme-... by-id path; everything else to the virtio-... by-id path. The
+// "failDiskPath" flag forces a resolution error, mirroring an EcsTeaClient /
+// DescribeInstanceTypes failure.
 func (a DiskManagerMock) GetDiskPath(path, diskId, instanceType string, category alicloud.DiskCategory) (string, error) {
-	return path, nil
+	if instanceType == "" || diskId == "" {
+		return path, nil
+	}
+	if a.mc.Flags["failDiskPath"] {
+		return path, fmt.Errorf("GetDiskPath injected failure (mock) for %s", instanceType)
+	}
+	suffix := diskId
+	if parts := strings.SplitN(diskId, "-", 2); len(parts) == 2 {
+		suffix = parts[1]
+	}
+	if strings.Contains(instanceType, "9i") {
+		return "/dev/disk/by-id/nvme-Alibaba_Cloud_Elastic_Block_Storage_" + suffix, nil
+	}
+	return "/dev/disk/by-id/virtio-" + suffix, nil
 }

--- a/src/bosh-alicloud-cpi/mock/instance_manager_mock.go
+++ b/src/bosh-alicloud-cpi/mock/instance_manager_mock.go
@@ -37,7 +37,22 @@ func (a InstanceManagerMock) CreateInstance(region string, args map[string]inter
 	if v, ok := args["ZoneId"]; ok {
 		inst.ZoneId = v.(string)
 	}
-	// ...
+	if v, ok := args["InstanceType"]; ok {
+		inst.InstanceType = v.(string)
+	}
+
+	// Mirror RunInstances creating + attaching the ephemeral data disk when a
+	// DataDisk.1 was requested. create_vm resolves this disk's path after the VM
+	// reaches Stopped, so it must be discoverable via GetDisks as Type == "data".
+	// The "noDataDisk" flag suppresses this to exercise create_vm's
+	// "no data disk found" branch.
+	if _, ok := args["DataDisk.1.Size"]; ok && !a.mc.Flags["noDataDisk"] {
+		_, d := a.mc.NewDisk(id)
+		d.Type = "data"
+		if v, ok := args["DataDisk.1.Category"]; ok {
+			d.Category = v.(string)
+		}
+	}
 
 	return id, nil
 }


### PR DESCRIPTION
## Problem

On NVMe-capable instance types (c9i / g9i / r9i / ...), attached disks are exposed as `/dev/nvme*n*` — there is no `/dev/vd*`. The CPI was hardcoding `/dev/vdb` as the ephemeral disk path in agent settings, and the agent looped forever waiting for that device:

```
[File System] DEBUG - Stat '/dev/vdb'
[File System] DEBUG - Checking if file exists /dev/vdb
... (every ~100ms)
```

Result: agent never mounts the ephemeral disk, never connects to NATS, director times out with `Timed out pinging VM ... agent ... after 600 seconds`.

## Fix

`alicloud/disk_manager.go::GetDiskPath` resolves the ephemeral disk to a `/dev/disk/by-id/` path via `DescribeInstanceTypes` (NvmeSupport: required). It just wasn't being called for the ephemeral disk. It can't be called at the existing call site (`NewDisksWithProps`) because the data disk's CID isn't known until `RunInstances` returns, so this PR resolves the path after the VM transitions to `Stopped` and before agent settings are written: look up the attached data disk via `GetDisks`, then call `GetDiskPath`.

Because a wrong ephemeral path leaves the agent hanging until the 600s ping timeout, resolution failures are **fatal and fail fast**: `GetDiskPath` now returns `(string, error)` (previously it logged and silently returned the legacy path), and `create_vm` treats any of the following as fatal — deleting the just-created VM and returning an error rather than writing bad agent settings:

- `GetDisks` fails
- no `data` disk is attached to the instance after create
- path resolution (`EcsTeaClient` / `DescribeInstanceTypes`) fails

## Behavior

- **NVMe-capable types**: agent gets the `/dev/disk/by-id/nvme-Alibaba_Cloud_Elastic_Block_Storage_<id>` path, follows the symlink, mounts the disk.
- **Non-NVMe types**: agent gets the `/dev/disk/by-id/virtio-<id>` by-id path (not the legacy `/dev/vdb`).
- **Resolution / discovery failure**: the VM is deleted and `create_vm` fails, so the director retries cleanly instead of the agent hanging to the 600s timeout.

`attach_disk` also calls `GetDiskPath`, but there the disk is already attached, so a resolution failure is non-fatal: it logs and proceeds with the best-effort path (unchanged behavior).

No agent-side change needed; bosh-agent resolves the by-id symlinks via `resolveCanonicalLink` in `platform/linux_platform.go`.

## Changes

| File | Change |
|------|--------|
| `alicloud/disk_manager.go` | `GetDiskPath` returns `(string, error)`; `EcsTeaClient` / `DescribeInstanceTypes` failures are now surfaced instead of swallowed. |
| `action/create_vm.go` | After the VM reaches Stopped, resolve the attached data disk's path; on `GetDisks` failure, missing data disk, or resolution error, delete the VM and fail. |
| `action/attach_disk.go` | Capture the `GetDiskPath` error; log and proceed with the best-effort path (non-fatal — disk already attached). |
| `mock/*` | `GetDiskPath` mock returns nvme/virtio by-id paths (keyed on instance type) and supports failure injection; `CreateInstance` attaches a `Type=data` disk when an ephemeral disk is requested; shared `TestContext.Flags` for injection. |
| `action/create_vm_test.go` | Tests: NVMe resolution, non-NVMe (virtio) resolution, `GetDisks` failure, missing data disk, path-resolution failure. |

## Related

AWS Nitro NVMe equivalent: [cloudfoundry/bosh-aws-cpi-release#196](https://github.com/cloudfoundry/bosh-aws-cpi-release/pull/196). That fix is multi-repo (CPI + agent + stemcell-builder) because it handles raw instance storage with no stable by-id symlinks. AliCloud creates stable by-id symlinks via udev for regular attached disks, so this is single-repo.
