### PR TITLE
ci: use available instance type for BATS

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -122,11 +122,8 @@ shared:
           echo "--- patched director.env ---"
           cat director-state/director.env
 
-# Alibaba Cloud cloud_efficiency disks have a 20 GB minimum (enforced by
-# the CPI in action/disks.go AmendSmallDiskSize, since 2017).  Two upstream
-# BATS tests create disks < 20 GB and assert on the exact byte-size, so they
-# always fail on alicloud.  Inject `skip` with an explanation so they appear
-# as *pending* instead of *failed*.
+# Apply provider-specific compatibility patches to upstream BATS. Guard the
+# instance-type patch so incompatible upstream template changes fail explicitly.
 - &patch-bats
   task: patch-bats
   config:
@@ -148,7 +145,23 @@ shared:
           "The CPI auto-amends smaller requests to 20 GB (AmendSmallDiskSize), "\
           "so byte-size assertions for < 20 GB disks will never match."
 
-          echo "=== Patching BATS: skipping tests incompatible with Alibaba Cloud disk constraints ==="
+          echo "=== Patching BATS for Alibaba Cloud ==="
+
+          # Upstream defaults to ecs.mn4.large, whose eu-central-1a stock is unreliable.
+          # Keep using the upstream run-bats task and only replace the template fallback.
+          template=bats/templates/cloud_config_alicloud.yml.erb
+          old_instance_type='properties.instance_type || "ecs.mn4.large"'
+          new_instance_type='properties.instance_type || "ecs.hfc6.xlarge"'
+          if ! grep -Fq "${old_instance_type}" "${template}"; then
+            echo "Expected instance type fallback not found in ${template}" >&2
+            exit 1
+          fi
+          sed -i "s#${old_instance_type}#${new_instance_type}#" "${template}"
+          if grep -Fq "${old_instance_type}" "${template}" || ! grep -Fq "${new_instance_type}" "${template}"; then
+            echo "Failed to update instance type fallback in ${template}" >&2
+            exit 1
+          fi
+          echo "  [instance type] ecs.mn4.large -> ecs.hfc6.xlarge"
 
           # 1. persistent_disks_spec.rb – "attaches multiple disks"
           #    Creates 5 GB + 4 GB disks, expects exact lsblk byte sizes.


### PR DESCRIPTION
## Summary

- replace the unreliable upstream BATS default `ecs.mn4.large` with `ecs.hfc6.xlarge` during the existing patch step
- keep using the upstream shared `run-bats` task
- fail explicitly if the upstream template anchor changes

## Context

Recent BATS runs repeatedly failed with `OperationDenied.NoStock` in `eu-central-1a` while creating `ecs.mn4.large` test VMs. The replacement instance type is currently reported as `WithStock` and supports the existing `cloud_efficiency` system and data disk combination.

## Validation

- `fly validate-pipeline -c ci/pipeline.yml`
- YAML parsing
- replacement and guard behavior against the current upstream `cloud_config_alicloud.yml.erb`