### PR TITLE
Finalize release v59.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,22 @@
 # Change Log
 
 All releases of the BOSH CPI for Alibaba Cloud will be documented in this file.
-## 59.0.0 (Unreleased)
+## 60.0.0 (Unreleased)
+
+## 59.0.0 (July 24, 2026)
+
+FEATURES:
+
+- Added the `update_disk` CPI method for in-place disk category, performance level, and size changes ([#208](https://github.com/cloudfoundry/bosh-alicloud-cpi-release/pull/208))
+  - Supports forward category changes such as `cloud_efficiency` to `cloud_essd`
+  - Returns `NotSupported` when Alibaba Cloud rejects an in-place disk specification change
+
+FIXES:
+
+- Resolved ephemeral disk device paths for NVMe-capable instance types ([#209](https://github.com/cloudfoundry/bosh-alicloud-cpi-release/pull/209))
+  - Uses stable `/dev/disk/by-id` paths for NVMe and virtio disks
+  - Fails fast and cleans up the VM when the ephemeral disk path cannot be resolved
+- Updated the BATS instance type to avoid intermittent `OperationDenied.NoStock` failures in `eu-central-1a` ([#212](https://github.com/cloudfoundry/bosh-alicloud-cpi-release/pull/212))
 
 ## 58.0.0 (June 10, 2026)
 
@@ -401,4 +416,3 @@ A temporary release for fixing a go sdk invalid timestamp error. (Changed in loc
 ## [r0]
 
 - Early ruby version.
-

--- a/releases/bosh-alicloud-cpi/bosh-alicloud-cpi-59.0.0.yml
+++ b/releases/bosh-alicloud-cpi/bosh-alicloud-cpi-59.0.0.yml
@@ -1,0 +1,28 @@
+name: bosh-alicloud-cpi
+version: 59.0.0
+commit_hash: e332d72
+uncommitted_changes: true
+jobs:
+- name: alicloud_cpi
+  version: f53ccfc4120077aeb67b1bb99bade9e7b95625db905dedf5f669d7aaf2f0eeda
+  fingerprint: f53ccfc4120077aeb67b1bb99bade9e7b95625db905dedf5f669d7aaf2f0eeda
+  sha1: sha256:0dcf5c8d9f8b7bb7d66d329118958a82a56a7f1c30c4b16e31731f3c251110de
+  packages:
+  - bosh-alicloud-cpi
+packages:
+- name: bosh-alicloud-cpi
+  version: 10d16c342cb6243c72103ff8e52ff4627db9f83e42ea098a2860bd96f816caed
+  fingerprint: 10d16c342cb6243c72103ff8e52ff4627db9f83e42ea098a2860bd96f816caed
+  sha1: sha256:66365f5bdea0a490ae35c05d8e3abf5004ce1efc7aee2482ddfc1bf57f7ae22a
+  dependencies:
+  - golang
+- name: golang
+  version: d5ed0c6b23b5604dcdc9765d33c81e1ed1376732bdfe88065d373aa56b4f9b29
+  fingerprint: d5ed0c6b23b5604dcdc9765d33c81e1ed1376732bdfe88065d373aa56b4f9b29
+  sha1: sha256:972d9351ff6035302e22bc550810e8016c910a54889741dbef17887b83812ce1
+  dependencies: []
+license:
+  version: d35e32db8d971404d5cca86a46140fabed166034a22aaa007b4a3948c758a934
+  fingerprint: d35e32db8d971404d5cca86a46140fabed166034a22aaa007b4a3948c758a934
+  sha1: sha256:3decd2727136e84fbcf37c735b85f6e9e3be8f24c1ce72e6b0b39cdb9ac4c80c
+no_compression: false

--- a/releases/bosh-alicloud-cpi/index.yml
+++ b/releases/bosh-alicloud-cpi/index.yml
@@ -23,6 +23,8 @@ builds:
     version: "13"
   5c6a1e2c-cbb7-4769-574f-32db5ca1d663:
     version: "2"
+  636bc606-d4ee-4d7a-6589-b841155756e1:
+    version: 59.0.0
   63c3ae78-6476-4edf-67a7-c5942c4caad5:
     version: 29.0.0
   6ca9ee74-d424-445f-6f0c-f0e1894f320b:


### PR DESCRIPTION
## Summary
- finalize BOSH Alibaba Cloud CPI release v59.0.0
- document `update_disk` support and NVMe ephemeral disk path handling
- advance the changelog to v60.0.0 (Unreleased)

## Verification
- integration, BATS, and end-to-end pipelines passed on the release source
- final tarball `release.MF` matches the committed v59 manifest
- final tarball SHA1: `5eca570b1a189ec5c41b5f9cda646db1a2dcc698`